### PR TITLE
Export Sektor as module

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,15 @@
 		<div>
 			<h3>Usage and API</h3>
 			<p>
-				Include the <code>sektor.js</code> file. Library is originally written in ES6 and transpiled using Babel.
+				Include the <code>sektor.js</code> file. Alternatively, import it as a module.
+			</p>
+			<pre>
+import { Sektor } from "sektor";
+window.Sektor = Sektor;
+</pre>
+
+			<p>
+				Library is originally written in ES6 and transpiled using Babel.
 				Source can be found in the <code>js/sektor.es6.js</code>.
 			</p>
 

--- a/js/sektor.es6.js
+++ b/js/sektor.es6.js
@@ -1,4 +1,4 @@
-function Sektor(selector, options) {
+export function Sektor(selector, options) {
   this.element = document.querySelector(selector);
 
   const defaultOptions = {

--- a/js/sektor.js
+++ b/js/sektor.js
@@ -1,7 +1,12 @@
 'use strict';
 
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+exports.Sektor = Sektor;
 function Sektor(selector, options) {
   this.element = document.querySelector(selector);
 
@@ -68,7 +73,7 @@ Sektor.prototype.step = function (angleOffset, endAngle, time, endTime) {
 Sektor.prototype.animateTo = function (angle) {
   var _this2 = this;
 
-  var time = arguments.length <= 1 || arguments[1] === undefined ? 300 : arguments[1];
+  var time = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 300;
 
   if (angle > 360) {
     angle = angle % 360;
@@ -84,7 +89,7 @@ Sektor.prototype.animateTo = function (angle) {
 };
 
 Sektor.prototype.getSector = function () {
-  var returnD = arguments.length <= 0 || arguments[0] === undefined ? false : arguments[0];
+  var returnD = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
 
   var options = this.options;
 


### PR DESCRIPTION
Hi, hope you would consider merging this pull request. I essentially make a very small change in order to use the library as a module.

- Add `export` to `Sektor` function
- Rebuild `sektor.js`
- Document usage